### PR TITLE
Initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# strong-url-defaults
-provide defaults for URLs
+strong-url-defaults
+===================
+
+Normalize URLs, providing defaults and overrides.
+
+## defaults = require('strong-url-defaults')
+
+Exports a single function, `defaults()`.
+
+## url = defaults(url, defaults[, overrides])
+
+- url {String} url to reformat
+- defaults {Object} components to set on `url` if they were not already set.
+- overrides {Object} components to set on `url` *even if* they were already set.
+
+Defaults can be any of:
+
+- `host`
+- `port`
+
+Its not possible to distinguish with `url.parse()` whether a path was supplied,
+so it can't be "defaulted".
+
+Overrides can be any of:
+
+- `host`
+- `port`
+- `path`

--- a/index.js
+++ b/index.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var parse = require('url').parse;
+var format = require('url').format;
+
+module.exports = normalize;
+
+function normalize(url, defaults, overrides) {
+  var _ = parse(url);
+
+  overrides = overrides || {};
+
+  function set(from, to) {
+    if (overrides[from])
+      _[to] = overrides[from];
+    else
+      _[to] = _[to] || defaults[from];
+  }
+
+  set('path', 'pathname');
+  set('host', 'hostname');
+  set('port', 'port');
+
+  _.slashes = true; // So we always get them
+
+  if (_.pathname === '/')
+    delete _.pathname; // So we don't get trailing '/' on URLs
+
+  delete _.host; // So .hostname and .port are used to format the URL
+
+  return format(_);
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/strongloop/strong-url-defaults/issues"
   },
   "scripts": {
-    "lint": "eslint *.js; jscs *.js",
+    "lint": "eslint *.js && jscs *.js",
     "test": "tap test.js"
   },
   "dependencies": {},

--- a/test.js
+++ b/test.js
@@ -1,0 +1,77 @@
+var fmt = require('util').format;
+var set = require('./');
+var tap = require('tap');
+
+function test(from, expect, defaults, overrides) {
+  tap.test(fmt('from %j to %j', from, expect), function(t) {
+    var got = set(from, defaults, overrides);
+    t.equal(got, expect);
+    t.end();
+  });
+}
+
+test(
+  'http:',
+  'http://localhost:8701',
+  {host: 'localhost', port: 8701});
+test(
+  'http://',
+  'http://localhost:8701',
+  {host: 'localhost', port: 8701});
+test(
+  'http://example.com',
+  'http://example.com:8701',
+  {host: 'localhost', port: 8701});
+test(
+  'http://:80',
+  'http://localhost:80',
+  {host: 'localhost', port: 8701});
+test(
+  'http://example.com:80',
+  'http://example.com:80',
+  {host: 'localhost', port: 8701});
+test(
+  'http+ssh:',
+  'http+ssh://localhost:8701',
+  {host: 'localhost', port: 8701});
+test(
+  'http+ssh://',
+  'http+ssh://localhost:8701',
+  {host: 'localhost', port: 8701});
+test(
+  'http+ssh://example.com',
+  'http+ssh://example.com:8701',
+  {host: 'localhost', port: 8701});
+test(
+  'http+ssh://:80',
+  'http+ssh://localhost:80',
+  {host: 'localhost', port: 8701});
+test(
+  'http+ssh://example.com:80',
+  'http+ssh://example.com:80',
+  {host: 'localhost', port: 8701});
+test(
+  'http:',
+  'http://localhost:8701/api',
+  {host: 'localhost', port: 8701},
+  {path: '/api'});
+test(
+  'http://',
+  'http://localhost:8701/api',
+  {host: 'localhost', port: 8701},
+  {path: '/api'});
+test(
+  'http://example.com',
+  'http://example.com:8701/api',
+  {host: 'localhost', port: 8701},
+  {path: '/api'});
+test(
+  'http://:80',
+  'http://localhost:80/api',
+  {host: 'localhost', port: 8701},
+  {path: '/api'});
+test(
+  'http://example.com:80',
+  'http://example.com:80/api',
+  {host: 'localhost', port: 8701},
+  {path: '/api'});


### PR DESCRIPTION
Will be used by strong-pm and strong-deploy. I won't hunt down every possible place, right now, but I'm in the process of adding this feature to strong-deploy, and I'll remove the duplicate code from at least one spot in strong-pm.

Connected to strongloop-internal/scrum-nodeops#289
